### PR TITLE
feat(logs): improvements to searching

### DIFF
--- a/apps/dokploy/components/dashboard/docker/logs/docker-logs-id.tsx
+++ b/apps/dokploy/components/dashboard/docker/logs/docker-logs-id.tsx
@@ -76,11 +76,18 @@ export const DockerLogsId: React.FC<Props> = ({ containerId, serverId }) => {
     if (!containerId) return;
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const wsUrl = `${protocol}//${
-      window.location.host
-    }/docker-container-logs?containerId=${containerId}&tail=${lines}&since=${since}&search=${search}${
-      serverId ? `&serverId=${serverId}` : ""
-    }`;
+    const params = new globalThis.URLSearchParams({
+      containerId,
+      tail: lines.toString(),
+      since,
+      search
+    });
+    
+    if (serverId) {
+      params.append('serverId', serverId);
+    }
+
+    const wsUrl = `${protocol}//${window.location.host}/docker-container-logs?${params.toString()}`;
     console.log("Connecting to WebSocket:", wsUrl);
     const ws = new WebSocket(wsUrl);
 
@@ -101,8 +108,7 @@ export const DockerLogsId: React.FC<Props> = ({ containerId, serverId }) => {
       console.log("WebSocket closed:", e.reason);
       setRawLogs(
         (prev) =>
-          prev +
-          `Connection closed!\nReason: ${
+          `${prev}Connection closed!\nReason: ${
             e.reason || "WebSocket was closed try to refresh"
           }\n`
       );
@@ -177,7 +183,7 @@ export const DockerLogsId: React.FC<Props> = ({ containerId, serverId }) => {
                 className="inline-flex h-9 text-sm text-white placeholder-gray-400 w-full sm:w-auto"
               />
               <Input
-                type="text"
+                type="search"
                 placeholder="Search logs..."
                 value={search}
                 onChange={handleSearch}

--- a/apps/dokploy/components/dashboard/docker/logs/terminal-line.tsx
+++ b/apps/dokploy/components/dashboard/docker/logs/terminal-line.tsx
@@ -2,6 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { getLogType, type LogLine } from "./utils";
 import React from "react";
+import { escapeRegExp } from 'lodash';
 
 interface LogLineProps {
   log: LogLine;
@@ -27,7 +28,7 @@ export function TerminalLine({ log, searchTerm }: LogLineProps) {
   const highlightMessage = (text: string, term: string) => {
     if (!term) return text;
 
-    const parts = text.split(new RegExp(`(${term})`, "gi"));
+    const parts = text.split(new RegExp(`(${escapeRegExp(term)})`, "gi"));
     return parts.map((part, index) =>
       part.toLowerCase() === term.toLowerCase() ? (
         <span key={index} className="bg-yellow-200 dark:bg-yellow-900">

--- a/apps/dokploy/server/wss/docker-container-logs.ts
+++ b/apps/dokploy/server/wss/docker-container-logs.ts
@@ -55,10 +55,10 @@ export const setupDockerContainerLogsWebSocketServer = (
 					.once("ready", () => {
 						const baseCommand = `docker container logs --timestamps --tail ${tail} ${
 							since === "all" ? "" : `--since ${since}`
-						  } --follow ${containerId}`;
-						const command = search 
-						  ? `${baseCommand} 2>&1 | grep -iF '${search}'` 
-						  : baseCommand;
+						} --follow ${containerId}`;
+						const command = search
+							? `${baseCommand} 2>&1 | grep -iF '${search}'`
+							: baseCommand;
 						client.exec(command, (err, stream) => {
 							if (err) {
 								console.error("Execution error:", err);
@@ -98,25 +98,18 @@ export const setupDockerContainerLogsWebSocketServer = (
 				const shell = getShell();
 				const baseCommand = `docker container logs --timestamps --tail ${tail} ${
 					since === "all" ? "" : `--since ${since}`
-				  } --follow ${containerId}`;
-				const command = search 
-				  ? `${baseCommand} 2>&1 | grep -iF '${search}'` 
-				  : baseCommand;
-				const ptyProcess = spawn(
-					shell,
-					[
-						"-c",
-						command,
-					],
-					{
-						name: "xterm-256color",
-						cwd: process.env.HOME,
-						env: process.env,
-						encoding: "utf8",
-						cols: 80,
-						rows: 30,
-					},
-				);
+				} --follow ${containerId}`;
+				const command = search
+					? `${baseCommand} 2>&1 | grep -iF '${search}'`
+					: baseCommand;
+				const ptyProcess = spawn(shell, ["-c", command], {
+					name: "xterm-256color",
+					cwd: process.env.HOME,
+					env: process.env,
+					encoding: "utf8",
+					cols: 80,
+					rows: 30,
+				});
 
 				ptyProcess.onData((data) => {
 					ws.send(data);

--- a/packages/server/src/wss/docker-container-logs.ts
+++ b/packages/server/src/wss/docker-container-logs.ts
@@ -56,7 +56,7 @@ export const setupDockerContainerLogsWebSocketServer = (
 					client
 						.once("ready", () => {
 							const command = `
-						bash -c "docker container logs --timestamps --tail ${tail} ${since === "all" ? "" : `--since ${since}`} --follow ${containerId} | grep -i '${search}'"
+						bash -c "docker container logs --timestamps --tail ${tail} ${since === "all" ? "" : `--since ${since}`} --follow ${containerId} | grep -iF '${search}'"
 					`;
 							client.exec(command, (err, stream) => {
 								if (err) {
@@ -91,7 +91,7 @@ export const setupDockerContainerLogsWebSocketServer = (
 					shell,
 					[
 						"-c",
-						`docker container logs --timestamps --tail ${tail} ${since === "all" ? "" : `--since ${since}`} --follow ${containerId} | grep -i '${search}'`,
+						`docker container logs --timestamps --tail ${tail} ${since === "all" ? "" : `--since ${since}`} --follow ${containerId} | grep -iF '${search}'`,
 					],
 					{
 						name: "xterm-256color",


### PR DESCRIPTION
I've been playing with this PR a bit and made some changes to:

- [x] escaping term before converting to regexp (bug)
- [x] treat term as literal string match in grep (perf/sec)
- [x] mark search field as type=search so it has a clear button (ux)
- [x] only pipe to grep if we're searching (perf)
- [x] when searching, pipe stderr to stdout so it is also filtered by grep (bug)

Still outstanding: 

no matches from grep results in:
```
Connection closed!
Reason: WebSocket was closed try to refresh
```

- [ ] show a message about no matches found
- [ ] Automatically fit terminal on window resize